### PR TITLE
(maint) Update Ruby version deprecation warning link

### DIFF
--- a/lib/puppet.rb
+++ b/lib/puppet.rb
@@ -127,7 +127,7 @@ module Puppet
   # Now that settings are loaded we have the code loaded to be able to issue
   # deprecation warnings. Warn if we're on a deprecated ruby version.
   if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new(Puppet::OLDEST_RECOMMENDED_RUBY_VERSION)
-    Puppet.deprecation_warning(_("Support for ruby version %{version} is deprecated and will be removed in a future release. See https://docs.puppet.com/puppet/latest/system_requirements.html#ruby for a list of supported ruby versions.") % { version: RUBY_VERSION })
+    Puppet.deprecation_warning(_("Support for ruby version %{version} is deprecated and will be removed in a future release. See https://docs.puppet.com/puppet/latest/system_requirements.html#prerequisites for a list of supported ruby versions.") % { version: RUBY_VERSION })
   end
 
   # Initialize puppet's settings. This is intended only for use by external tools that are not

--- a/locales/ja/puppet.po
+++ b/locales/ja/puppet.po
@@ -53,10 +53,10 @@ msgstr "Puppet %{version}ではruby 1.9.3以上が必要です。"
 msgid ""
 "Support for ruby version %{version} is deprecated and will be removed in a "
 "future release. See "
-"https://docs.puppet.com/puppet/latest/system_requirements.html#ruby for a "
+"https://docs.puppet.com/puppet/latest/system_requirements.html#prerequisites for a "
 "list of supported ruby versions."
 msgstr ""
-"rubyバージョン%{version}のサポートは廃止予定であり、今後のリリースで廃止されます。サポートされているrubyのバージョンについては、https://docs.puppet.com/puppet/latest/system_requirements.html#rubyを参照してください。"
+"rubyバージョン%{version}のサポートは廃止予定であり、今後のリリースで廃止されます。サポートされているrubyのバージョンについては、https://docs.puppet.com/puppet/latest/system_requirements.html#prerequisitesを参照してください。"
 
 #: ../lib/puppet.rb:177
 msgid ""

--- a/locales/puppet.pot
+++ b/locales/puppet.pot
@@ -53,7 +53,7 @@ msgid "Puppet %{version} requires ruby 2.3.0 or greater."
 msgstr ""
 
 #: ../lib/puppet.rb:130
-msgid "Support for ruby version %{version} is deprecated and will be removed in a future release. See https://docs.puppet.com/puppet/latest/system_requirements.html#ruby for a list of supported ruby versions."
+msgid "Support for ruby version %{version} is deprecated and will be removed in a future release. See https://docs.puppet.com/puppet/latest/system_requirements.html#prerequisites for a list of supported ruby versions."
 msgstr ""
 
 #: ../lib/puppet.rb:188


### PR DESCRIPTION
The named anchor "#ruby" on the system requirements page has been
replaced with a new named anchor "#prerequisites".